### PR TITLE
doc: versioning and releasing

### DIFF
--- a/proposals/incubation/openfeature.md
+++ b/proposals/incubation/openfeature.md
@@ -45,6 +45,8 @@ As an existing Sandbox project this is already in place
 
 ### **_Clear versioning scheme & release methodology_**
 
+As outlined by our [Repository requirements](https://github.com/open-feature/.github/blob/main/CONTRIBUTING.md#repository-requirements), OpenFeature artifacts adhere to semantic versioning and include meaningful change logs. The OpenFeature specification includes [Document status](https://github.com/open-feature/spec/tree/main/specification#document-statuses) definitions, which are used to indicate the stability level of each specification section.
+
 ### **_Demonstrate a substantial ongoing flow of commits and merged contributions._**
 
 ### **_Security_**


### PR DESCRIPTION
Adds a small section about versioning, mostly linking to existing docs.

[This](https://github.com/open-feature/.github/pull/29) should be merged first.

Closes: https://github.com/open-feature/toc-proposal/issues/5